### PR TITLE
Fix potential overflow when we print verbose physical plan

### DIFF
--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -100,7 +100,7 @@ use async_trait::async_trait;
 use datafusion_physical_plan::async_func::{AsyncFuncExec, AsyncMapper};
 use futures::{StreamExt, TryStreamExt};
 use itertools::{multiunzip, Itertools};
-use log::debug;
+use log::{debug, trace};
 use tokio::sync::Mutex;
 
 /// Physical query planner that converts a `LogicalPlan` to an
@@ -2093,7 +2093,15 @@ impl DefaultPhysicalPlanner {
             "Optimized physical plan:\n{}\n",
             displayable(new_plan.as_ref()).indent(false)
         );
-        debug!("Detailed optimized physical plan:\n{new_plan:?}");
+
+        // This is potentially very large, so only log at trace level,
+        // otherwise it can overflow the tokio runtime stack because without
+        // tree_maximum_render_width setting.
+        //
+        // For example:
+        // thread 'tokio-runtime-worker' has overflowed its stack
+        // fatal runtime error: stack overflow, aborting
+        trace!("Detailed optimized physical plan:\n{new_plan:?}");
         Ok(new_plan)
     }
 

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -100,7 +100,7 @@ use async_trait::async_trait;
 use datafusion_physical_plan::async_func::{AsyncFuncExec, AsyncMapper};
 use futures::{StreamExt, TryStreamExt};
 use itertools::{multiunzip, Itertools};
-use log::{debug, trace};
+use log::debug;
 use tokio::sync::Mutex;
 
 /// Physical query planner that converts a `LogicalPlan` to an

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2095,8 +2095,7 @@ impl DefaultPhysicalPlanner {
         );
 
         // This is potentially very large, so only log at trace level,
-        // otherwise it can overflow the tokio runtime stack because without
-        // tree_maximum_render_width setting.
+        // otherwise it can overflow the tokio runtime stack.
         //
         // For example:
         // thread 'tokio-runtime-worker' has overflowed its stack

--- a/datafusion/core/src/physical_planner.rs
+++ b/datafusion/core/src/physical_planner.rs
@@ -2094,13 +2094,10 @@ impl DefaultPhysicalPlanner {
             displayable(new_plan.as_ref()).indent(false)
         );
 
-        // This is potentially very large, so only log at trace level,
-        // otherwise it can overflow the tokio runtime stack.
-        //
-        // For example:
-        // thread 'tokio-runtime-worker' has overflowed its stack
-        // fatal runtime error: stack overflow, aborting
-        trace!("Detailed optimized physical plan:\n{new_plan:?}");
+        debug!(
+            "Detailed optimized physical plan:\n{}\n",
+            displayable(new_plan.as_ref()).indent(true)
+        );
         Ok(new_plan)
     }
 


### PR DESCRIPTION
Here is the PR which is in apache datafusion:
https://github.com/apache/datafusion/pull/17383


This PR fix it to make debug log not using pure physical plan printing.

It make our e2e testing failed with:

```rust
2025-09-26T06:12:05.638390Z DEBUG datafusion::physical_planner: Optimized physical plan:
CoalesceBatchesExec: target_batch_size=8192
  HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(c_customer_sk@0, c_customer_sk@0), (c_current_cdemo_sk@1, c_current_cdemo_sk@1), (c_current_hdemo_sk@2, c_current_hdemo_sk@2), (c_current_addr_sk@3, c_current_addr_sk@3), (c_first_shipto_date_sk@4, c_first_shipto_date_sk@4), (c_first_sales_date_sk@5, c_first_sales_date_sk@5), (c_birth_day@6, c_birth_day@6), (c_birth_year@7, c_birth_year@7), (c_customer_id@8, c_customer_id@8), (c_salutation@9, c_salutation@9), (c_first_name@10, c_first_name@10), (c_last_name@11, c_last_name@11), (c_preferred_cust_flag@12, c_preferred_cust_flag@12), (c_birth_country@13, c_birth_country@13), (c_email_address@14, c_email_address@14), (c_last_review_date@15, c_last_review_date@15), (c_birth_month@16, c_birth_month@16)]
    ProjectionExec: expr=[c_customer_sk@0 as c_customer_sk, c_current_cdemo_sk@1 as c_current_cdemo_sk, c_current_hdemo_sk@2 as c_current_hdemo_sk, c_current_addr_sk@3 as c_current_addr_sk, c_first_shipto_date_sk@4 as c_first_shipto_date_sk, c_first_sales_date_sk@5 as c_first_sales_date_sk, c_birth_day@6 as c_birth_day, c_birth_year@8 as c_birth_year, c_customer_id@9 as c_customer_id, c_salutation@10 as c_salutation, c_first_name@11 as c_first_name, c_last_name@12 as c_last_name, c_preferred_cust_flag@13 as c_preferred_cust_flag, c_birth_country@14 as c_birth_country, c_email_address@15 as c_email_address, c_last_review_date@16 as c_last_review_date, lpad(CAST(c_birth_month@7 AS Utf8), 2, 0) as c_birth_month]
      DataSourceExec: file_groups={1 group: [[test/delta_encoding_required_column.parquet]]}, projection=[c_customer_sk, c_current_cdemo_sk, c_current_hdemo_sk, c_current_addr_sk, c_first_shipto_date_sk, c_first_sales_date_sk, c_birth_day, c_birth_month, c_birth_year, c_customer_id, c_salutation, c_first_name, c_last_name, c_preferred_cust_flag, c_birth_country, c_email_address, c_last_review_date], file_type=parquet
    CooperativeExec
      FileScanExec: table = atlas.test.delta_encoding_required_column_partitioned, scan_direction=Native, page_size=1024, partitions=[0, 1]



thread 'tokio-runtime-worker' has overflowed its stack
fatal runtime error: stack overflow, aborting
```
