### PR TITLE
[branch-52] perf: skip ensure_distribution rebuild when children are unchanged

### DIFF
--- a/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_distribution.rs
@@ -3706,3 +3706,38 @@ fn adjust_input_keys_ordering_no_transform_for_filter_scan() -> Result<()> {
     );
     Ok(())
 }
+
+/// Verifies the `ensure_distribution` fast path: when no child of a node is
+/// replaced (no `RepartitionExec` or `SortExec` injection is required),
+/// the rule must reuse the input `Arc<dyn ExecutionPlan>` unchanged instead
+/// of calling `with_new_children`. For a deep `ProjectionExec` chain over a
+/// single-partition scan with `target_partitions = 1`, every node hits this
+/// fast path, so the root returned by `ensure_distribution` must be the
+/// same `Arc` as the input.
+///
+/// Regression test for the optimization that avoids
+/// `ProjectionExec::with_new_children` (which recomputes schema, equivalence
+/// properties, output ordering, and partitioning) on the common point-query
+/// plan shape. Cherry-pick of upstream apache/datafusion#22521.
+#[test]
+fn ensure_distribution_reuses_plan_arc_when_no_redistribution_needed() -> Result<()> {
+    let scan = parquet_exec();
+    let proj1 = projection_exec_with_alias(
+        scan,
+        vec![
+            ("a".to_string(), "a".to_string()),
+            ("b".to_string(), "b".to_string()),
+        ],
+    );
+    let proj2 =
+        projection_exec_with_alias(proj1, vec![("a".to_string(), "a".to_string())]);
+    let plan: Arc<dyn ExecutionPlan> = proj2;
+
+    let result = ensure_distribution_helper(Arc::clone(&plan), 1, false)?;
+
+    assert!(
+        Arc::ptr_eq(&result, &plan),
+        "ensure_distribution must reuse the input Arc when no children require redistribution"
+    );
+    Ok(())
+}

--- a/datafusion/physical-optimizer/src/enforce_distribution.rs
+++ b/datafusion/physical-optimizer/src/enforce_distribution.rs
@@ -58,7 +58,9 @@ use datafusion_physical_plan::tree_node::PlanContext;
 use datafusion_physical_plan::union::{InterleaveExec, UnionExec, can_interleave};
 use datafusion_physical_plan::windows::WindowAggExec;
 use datafusion_physical_plan::windows::{BoundedWindowAggExec, get_best_fitting_window};
-use datafusion_physical_plan::{Distribution, ExecutionPlan, Partitioning};
+use datafusion_physical_plan::{
+    Distribution, ExecutionPlan, Partitioning, with_new_children_if_necessary,
+};
 
 use itertools::izip;
 
@@ -1529,7 +1531,16 @@ pub fn ensure_distribution(
         //           Data
         Arc::new(InterleaveExec::try_new(children_plans)?)
     } else {
-        plan.with_new_children(children_plans)?
+        // Route through `with_new_children_if_necessary` so the common
+        // case where no child was replaced above skips the expensive
+        // `with_new_children` rebuild. For nodes like `ProjectionExec`,
+        // `with_new_children` recomputes schema / equivalence properties /
+        // output ordering via `try_new` even when the input Arcs are
+        // identical, which dominates `ensure_distribution` time on deep
+        // projection stacks over plans where no distribution change
+        // applies (point queries with no join / aggregate / unmet
+        // ordering). Cherry-pick of upstream apache/datafusion#22521.
+        with_new_children_if_necessary(plan, children_plans)?
     };
 
     let mut optimized_distribution_ctx =


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [apache/datafusion#22521](https://github.com/apache/datafusion/pull/22521) (approved by 2010YOUY01 and alamb, awaiting maintainer merge) into our branch-52 fork.

`ensure_distribution` was calling `plan.with_new_children(children_plans)` unconditionally after collecting the (possibly redistributed) children, even when none of the children were actually replaced. For nodes like `ProjectionExec` that path recomputes schema / equivalence properties / output ordering / partitioning via `try_new` — pure overhead when child Arcs are pointer-identical.

Routes the non-`UnionExec` branch through the existing `with_new_children_if_necessary` helper, which does the `Arc::ptr_eq` short-circuit and reuses the input plan when no children changed.

## Why pick now

Linear [X-2631](https://linear.app/massive-com/issue/X-2631/skip-unnecessary-plan-rebuild-in-enforcedistribution-for-non-join). Atlas reference-cluster query servers run on branch-52-pinned DataFusion and hit the slow path on every point-query plan node. Profiling on NY5 prod showed `ProjectionExec::with_new_children` as the single largest cost inside `ensure_distribution` (1.94s of a 2.87s rule-time slice in a 60s CPU sample).

## Adaptations from upstream

- Upstream lives at `datafusion/physical-optimizer/src/ensure_requirements/enforce_distribution.rs`; branch-52 keeps the flat path `datafusion/physical-optimizer/src/enforce_distribution.rs`. Same logic, different module path.
- Upstream uses `plan.is::<UnionExec>()`; branch-52 still has `plan.as_any().is::<UnionExec>()`. Adjusted.

## Affects

- Staging: query servers will see the fast path after a DF rev bump (separate PR).
- Production: same, after staging soak.

## Tests

`cargo test --release -p datafusion --test core_integration -- physical_optimizer::enforce_distribution` — 63/63 pass (62 pre-existing + 1 new regression test `ensure_distribution_reuses_plan_arc_when_no_redistribution_needed`).

## Micro-benchmark from upstream PR

Plan shape: 30-deep `ProjectionExec` stack over a sorted parquet scan, 5000 iterations.

- Without fix: 852.74 ms total, 170.55 us/call
- With fix:    296.81 ms total, 59.36 us/call
- ~2.87x speedup, -65% CPU per call