### PR TITLE
[X-3253] Fix projected hash join sort pushdown

### DIFF
--- a/datafusion/core/tests/physical_optimizer/enforce_sorting.rs
+++ b/datafusion/core/tests/physical_optimizer/enforce_sorting.rs
@@ -34,7 +34,7 @@ use arrow::compute::{SortOptions};
 use arrow::datatypes::{DataType, SchemaRef};
 use datafusion_common::config::{ConfigOptions, CsvOptions};
 use datafusion_common::tree_node::{TreeNode, TransformedResult};
-use datafusion_common::{create_array, Result, TableReference};
+use datafusion_common::{create_array, NullEquality, Result, TableReference};
 use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::source::DataSourceExec;
 use datafusion_expr_common::operator::Operator;
@@ -46,6 +46,7 @@ use datafusion_physical_expr_common::sort_expr::{
 use datafusion_physical_expr::{Distribution, Partitioning};
 use datafusion_physical_expr::expressions::{col, BinaryExpr, Column, NotExpr};
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
+use datafusion_physical_plan::joins::{HashJoinExec, PartitionMode};
 use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion_physical_plan::sorts::sort::SortExec;
@@ -223,6 +224,45 @@ async fn test_remove_unnecessary_sort5() -> Result<()> {
     HashJoinExec: mode=Partitioned, join_type=Inner, on=[(col_a@0, c@2)]
       DataSourceExec: partitions=1, partition_sizes=[0]
       DataSourceExec: file_groups={1 group: [[x]]}, projection=[a, b, c, d, e], output_ordering=[a@0 ASC], file_type=parquet
+    ");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_hash_join_interleaved_projection_preserves_parent_sort() -> Result<()> {
+    let left_schema = create_test_schema()?;
+    let right_schema = create_test_schema2()?;
+    let left = parquet_exec(left_schema.clone());
+    let right = parquet_exec(right_schema.clone());
+    let on = vec![(
+        Arc::new(Column::new_with_schema("nullable_col", &left_schema)?) as _,
+        Arc::new(Column::new_with_schema("col_a", &right_schema)?) as _,
+    )];
+    let join = Arc::new(HashJoinExec::try_new(
+        left,
+        right,
+        on,
+        None,
+        &JoinType::Right,
+        // Interleave a right-side column before a left-side column.
+        Some(vec![2, 0]),
+        PartitionMode::CollectLeft,
+        NullEquality::NullEqualsNothing,
+        false,
+    )?);
+    let ordering = [sort_expr("nullable_col", &join.schema())].into();
+    let physical_plan = sort_exec(ordering, join);
+
+    let config = ConfigOptions::new();
+    let optimized_plan =
+        EnforceSorting::new().optimize(Arc::clone(&physical_plan), &config)?;
+    let optimized_plan = SanityCheckPlan::new().optimize(optimized_plan, &config)?;
+
+    assert_snapshot!(displayable(optimized_plan.as_ref()).indent(true), @r"
+    SortExec: expr=[nullable_col@1 ASC], preserve_partitioning=[false]
+      HashJoinExec: mode=CollectLeft, join_type=Right, on=[(nullable_col@0, col_a@0)], projection=[col_a@2, nullable_col@0]
+        DataSourceExec: file_groups={1 group: [[x]]}, projection=[nullable_col, non_nullable_col], file_type=parquet
+        DataSourceExec: file_groups={1 group: [[x]]}, projection=[col_a, col_b], file_type=parquet
     ");
     Ok(())
 }

--- a/datafusion/physical-optimizer/src/enforce_sorting/sort_pushdown.rs
+++ b/datafusion/physical-optimizer/src/enforce_sorting/sort_pushdown.rs
@@ -911,12 +911,11 @@ fn handle_hash_join(
     } else {
         column_indices.iter().collect()
     };
-    let len_of_left_fields = projected_indices
-        .iter()
-        .filter(|ci| ci.side == JoinSide::Left)
-        .count();
-
-    let all_from_right_child = all_indices.iter().all(|i| *i >= len_of_left_fields);
+    let all_from_right_child = all_indices.iter().all(|i| {
+        projected_indices
+            .get(*i)
+            .is_some_and(|ci| ci.side == JoinSide::Right)
+    });
 
     let plan_children = plan.children();
 


### PR DESCRIPTION
## Which issue does this PR close?

- N/A

## Rationale for this change

`handle_hash_join` decides whether a parent sort requirement can be pushed to the order-preserving right child. With an embedded projection, it counted the projected left-side fields and assumed they formed a contiguous prefix of the output.

That assumption is false for an interleaved projection such as `[right.col_a, left.nullable_col]`. A sort on output index 1 (`left.nullable_col`) was classified as a right-side sort because `1 >= left_field_count`. `EnforceSorting` then removed the required parent sort and inserted `SortExec col_a@0` on the right child.

This occurred in the Form 4 materialization plan when an ordered `ARRAY_AGG(ticker)` sat above a projected right hash join. The wrong child sort ultimately produced a plan rejected by `SanityCheckPlan`.

## What changes are included in this PR?

- Determine each required output column's source directly from the projected `ColumnIndex.side` instead of comparing its output index with a left-field count.
- Add an optimizer regression test with an interleaved right/left hash-join projection. The test verifies that a left-side ordering remains above the join and runs the optimized plan through `SanityCheckPlan`.

## Are these changes tested?

Yes.

- On unmodified `branch-54`, the new regression test fails: the parent `SortExec nullable_col@1` disappears and the right child incorrectly gets `SortExec col_a@0`.
- With this PR, the same test passes and preserves `SortExec nullable_col@1` above the join.
- `cargo fmt --all`
- `CARGO_INCREMENTAL=0 cargo test -p datafusion --test core_integration physical_optimizer::enforce_sorting::test_hash_join_interleaved_projection_preserves_parent_sort -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo clippy --all-targets --all-features -- -D warnings`

## Are there any user-facing changes?

No public API changes. Queries with interleaved projected hash-join outputs no longer receive an incorrect pushed-down sort or fail physical-plan validation as a result.
